### PR TITLE
feat : Add Deselect Functionality for Booking Slots

### DIFF
--- a/lib/src/core/booking_controller.dart
+++ b/lib/src/core/booking_controller.dart
@@ -93,7 +93,11 @@ class BookingController extends ChangeNotifier {
   }
 
   void selectSlot(int idx) {
-    _selectedSlot = idx;
+    if (_selectedSlot == idx) {
+      _selectedSlot = -1;
+    } else {
+      _selectedSlot = idx;
+    }
     notifyListeners();
   }
 


### PR DESCRIPTION
### **Summary**
This PR introduces the functionality to allow users to deselect a previously selected booking slot. It enhances the user experience by providing a more flexible and intuitive interaction when selecting time slots.

### **Changes**
- Modified the booking slot selection logic to support toggling between selection and deselection.
- Users can now click on an already selected slot to deselect it, allowing them to undo slot selection without booking.
- Updated the visual state of deselected slots to revert to the "available" state.

### **Motivation**
Previously, once a slot was selected, it could only be replaced by selecting another slot. This addition allows users to deselect a slot, which improves usability, particularly in cases where users may change their minds about their selection before confirming the booking.

### **Testing**
- Tested deselection functionality on various devices to ensure consistent behavior.
- Verified that once deselected, the slot returns to the available state and can be selected again without issues.

Closes #60 